### PR TITLE
Add Travis CI badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+|build|
+
 What is Attic?
 --------------
 Attic is a deduplicating backup program. The main goal of Attic is to provide
@@ -55,3 +57,7 @@ The tests are in the attic/testsuite package. To run the test suite use the
 following command::
 
   $ fakeroot -u python -m attic.testsuite.run
+
+.. |build| image:: https://travis-ci.org/attic/merge.svg
+        :alt: Build Status
+        :target: https://travis-ci.org/attic/merge


### PR DESCRIPTION
In #1 there was confusion about if the test run correctly.
Travis CI is already enabled on the original repository (see .travis.yml and https://travis-ci.org/jborg/attic)

Enable it for this repository here: https://travis-ci.org/attic/merge

Maybe landscape.io and other GH-3rd party apps are also also interesting: see https://landscape.io/github/hubx/merge/1 although it produces some false-positives at the moment and needs some fine-tuning. 